### PR TITLE
Supporting multiple folders taking name from current working directory

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,8 +2,9 @@
 define([
   'commander',
   'fs',
-  './config'
-], function (program, fs, config) {
+  './config',
+    'path'
+], function (program, fs, config, path) {
 
   var Auth = {
     cfgPath: config.cfgPath || null,
@@ -13,9 +14,10 @@ define([
     checkConfig: function () {
       if (fs.existsSync(this.fullPath)) {
         configObject = JSON.parse(fs.readFileSync(this.fullPath, 'utf-8'));
-
         config.auth = configObject.auth;
-        config.options = configObject.options;
+	    var dirname = path.basename(process.cwd());
+	    config.auth.url = config.auth.url + dirname+ '/';
+          config.options = configObject.options;
 
         if (!config.options) {
           console.log('Ops! Seems like your ' + this.fullPath + ' is out of date. Please reset you configuration.');

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "cheerio": "^0.22.0",
     "cli-table": "~0.2.0",
     "commander": "~1.1.1",
-    "gmail-sender": "^0.1.2",
     "moment": "^2.10.2",
     "openurl": "^1.1.0",
     "request": "^2.76.0",


### PR DESCRIPTION
Currently only the repo supplied in the config.auth is supported for pull requests. After this change any current working directory is searched on bitbucket for pull requests. Since it might be a breaking change,any other idea to handle it? Please let me know and I'll make the desired changes for review.